### PR TITLE
Fixes hosted-zone validation for 13char ALB hzs

### DIFF
--- a/templates/aws-refarch-wordpress-05-route53.yaml
+++ b/templates/aws-refarch-wordpress-05-route53.yaml
@@ -34,7 +34,7 @@ Parameters:
     Description: The DNS endpoint - CloudFront DNS if using CloudFront else Public ELB DNS name.
     Type: String
   DnsHostId:
-    AllowedPattern: ^[A-Z0-9]{14}$
+    AllowedPattern: ^[A-Z0-9]{13,14}$
     Description: The DNS host zone id - 'Z2FDTNDATAQYW2' if using CloudFront else Public ELB host zone id.
     Type: String
   WPDomainName:


### PR DESCRIPTION
*Description of changes:* 
Hosted zones for ALBs can apparently be 13 characters. This fix accommodates that. 

```
➜  ~ aws elbv2 describe-load-balancers | jq '.LoadBalancers[0].CanonicalHostedZoneId' -r        
Z1H1FL5HABSF5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
